### PR TITLE
Add support for parsing SCTE35-style markers

### DIFF
--- a/m3u/AttributeList.js
+++ b/m3u/AttributeList.js
@@ -18,6 +18,7 @@ var dataTypes = AttributeList.dataTypes = {
   'name'       : 'quoted-string',
   'program-id' : 'decimal-integer',
   'resolution' : 'decimal-resolution',
+  'sctedata'   : 'enumerated-string',
   'subtitles'  : 'quoted-string',
   'title'      : 'enumerated-string',
   'type'       : 'enumerated-string',


### PR DESCRIPTION
Add support for SCTE35 enhanced markers
#EXT-OATCLS-SCTE35:/DAlAAAAAAAAAP/wFAUAAAABf+/+AAFT134ApMuAAAIAAAAAWcVHiA==
#EXT-X-CUE-OUT:120
#EXTINF:6,
high_00001.ts
#EXT-X-CUE-OUT-CONT:ElapsedTime=8,Duration=120,SCTE35=/DAlAAAAAAAAAP/wFAUAAAABf+/+AAFT134ApMuAAAIAAAAAWcVHiA==
#EXTINF:6,
high_00002.ts
#EXT-X-CUE-OUT-CONT:ElapsedTime=14,Duration=120,SCTE35=/DAlAAAAAAAAAP/wFAUAAAABf+/+AAFT134ApMuAAAIAAAAAWcVHiA==
#EXTINF:6,
high_00003.ts
#EXT-X-CUE-OUT-CONT:ElapsedTime=20,Duration=120,SCTE35=/DAlAAAAAAAAAP/wFAUAAAABf+/+AAFT134ApMuAAAIAAAAAWcVHiA==
#EXTINF:6,
00004.ts
....


Correlating PR being added on hls-vodtolive