### PR TITLE
BugFix : Wrong Placement of #EXT-X-CUE-IN

### DIFF
--- a/m3u/PlaylistItem.js
+++ b/m3u/PlaylistItem.js
@@ -54,7 +54,9 @@ PlaylistItem.prototype.toString = function toString() {
   if (this.get('byteRange') != null) {
     output.push('#EXT-X-BYTERANGE:' + this.get('byteRange'));
   }
-  output.push(this.get('uri'));
+  if(this.get('uri')) {
+    output.push(this.get('uri'));
+  }
 
   return output.join('\n');
 };

--- a/parser.js
+++ b/parser.js
@@ -17,6 +17,7 @@ var m3uParser = module.exports = function m3uParser() {
 
   this.cueOut = null;
   this.cueOutCont = null;
+  this.cueIn = null;
   this.assetData = null;
   this.scteData = null;
   this.dateRangeData = null;
@@ -24,6 +25,11 @@ var m3uParser = module.exports = function m3uParser() {
   this.on('data', this.parse.bind(this));
   var self = this;
   this.on('end', function() {
+    if(this.cueIn == true) {
+		  this.addItem(new PlaylistItem);
+		  this.currentItem.set('cuein', true);
+		  this.cueIn = null;
+			}
     self.emit('m3u', self.m3u);
   });
 };
@@ -109,6 +115,11 @@ m3uParser.prototype['EXTINF'] = function parseInf(data) {
     this.cueOutCont = null;
   }
 
+  if (this.cueIn !== null) {
+    this.currentItem.set('cuein', true);
+    this.cueIn = null;
+  }
+
   if (this.dateRangeData !== null) {
     this.currentItem.set('daterange', this.dateRangeData);
     this.dateRangeData = null;
@@ -163,7 +174,7 @@ m3uParser.prototype['EXT-OATCLS-SCTE35'] = function parseInf(data) {
 }
 
 m3uParser.prototype['EXT-X-CUE-IN'] = function parseInf() {
-  this.currentItem.set('cuein', true);
+  this.cueIn = true;
 }
 
 m3uParser.prototype['EXT-X-ASSET'] = function parseInf(data) {

--- a/test/acceptance/parse-playlist.js
+++ b/test/acceptance/parse-playlist.js
@@ -70,24 +70,24 @@ describe('parsing playlist m3u8', function() {
     });
   });
 
-  describe('13th PlaylistItem', function() {
+  describe('43th PlaylistItem', function() {
     it('has a cue in', function(done) {
       var parser = getParser();
 
       parser.on('m3u', function(m3u) {
-        var item = m3u.items.PlaylistItem[12];
+        var item = m3u.items.PlaylistItem[13];
         item.get('cuein').should.equal(true);
         done();
       });
     });
   });
 
-  describe('14th PlaylistItem', function() {
+  describe('15th PlaylistItem', function() {
     it('has not a cue in', function(done) {
       var parser = getParser();
 
       parser.on('m3u', function(m3u) {
-        var item = m3u.items.PlaylistItem[13];
+        var item = m3u.items.PlaylistItem[14];
         should.not.exist(item.get('cuein'));
         done();
       });
@@ -99,10 +99,10 @@ describe('parsing playlist m3u8', function() {
       var parser = getParser();
 
       parser.on('m3u', function(m3u) {
-        var item = m3u.items.PlaylistItem[16];
+        var item = m3u.items.PlaylistItem[17];
         item.get('cuein').should.equal(true);
         done();
-      });      
+      });
     });
   });
 });

--- a/test/acceptance/parse-playlist.js
+++ b/test/acceptance/parse-playlist.js
@@ -70,7 +70,7 @@ describe('parsing playlist m3u8', function() {
     });
   });
 
-  describe('43th PlaylistItem', function() {
+  describe('14th PlaylistItem', function() {
     it('has a cue in', function(done) {
       var parser = getParser();
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -140,14 +140,14 @@ describe('parser', function() {
   describe('#EXT-X-CUE-IN', function() {
     it('should indicate cue in is true if present', function() {
       var parser = getParser();
-    
+
       parser.EXTINF('4.5,some title');
       parser['EXT-X-CUE-IN']();
       parser.currentItem.constructor.name.should.eql('PlaylistItem');
-      parser.currentItem.get('cuein').should.eql(true);
+      should.not.exist(parser.currentItem.get('cuein'));
       parser.EXTINF('3.5,some title');
       parser.currentItem.constructor.name.should.eql('PlaylistItem');
-      should.not.exist(parser.currentItem.get('cuein'));
+      parser.currentItem.get('cuein').should.eql(true);
     });
 
   });
@@ -160,7 +160,7 @@ describe('parser', function() {
       parser.EXTINF('4.5,some title');
       parser.currentItem.constructor.name.should.eql('PlaylistItem');
       parser.currentItem.get('daterange')['START-DATE'].should.eql('2020-11-21T10:00:00.000Z');
-      parser.currentItem.toString().should.eql('#EXT-X-DATERANGE:START-DATE="2020-11-21T10:00:00.000Z",X-CUSTOM="MY CUSTOM TAG"\n#EXTINF:4.5000,some title\n');
+      parser.currentItem.toString().should.eql('#EXT-X-DATERANGE:START-DATE="2020-11-21T10:00:00.000Z",X-CUSTOM="MY CUSTOM TAG"\n#EXTINF:4.5000,some title');
     });
   });
 


### PR DESCRIPTION
@birme @craigmc-ottera 

After parse and then call m3u.toString(), somehow the tag #EXT-X-CUE-IN place in incorrect position.

For example if I have original m3u8 like this :

#EXT-X-CUE-OUT:DURATION=6.0000
#EXTINF:2.0000,
video-0006.ts
#EXTINF:4.0000,
video-0007.ts
#EXT-X-CUE-IN

After parse and then m3u.toString(), the result become like this :

#EXT-X-CUE-OUT:DURATION=6.0000
#EXTINF:2.0000,
video-0006.ts
#EXT-X-CUE-IN
#EXTINF:4.0000,
video-0007.ts

Expected output should be the same like the original below :

#EXT-X-CUE-OUT:DURATION=6.0000
#EXTINF:2.0000,
video-0006.ts
#EXTINF:4.0000,
video-0007.ts
#EXT-X-CUE-IN

This PR is to fix the above issue.