### PR TITLE
chore: fix unit test, string comparison issue

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/test/m3u.test.js
+++ b/test/m3u.test.js
@@ -235,7 +235,7 @@ function getVariantM3U(callback) {
     var stream = Readable.from(buffer);
     stream.pipe(parser);
     parser.on('m3u', function(m3u) {
-      callback(null, m3u, buffer.toString());
+      callback(null, m3u, buffer.toString().replace(/(\r\n)/gm, '\n'));
     });
   })
 }


### PR DESCRIPTION
A parsed `m3u` object turned into a string through `.toString()` only uses `\n` for line breaks.  When making a comparison with one of the test m3u8 files, `buffer.toString()`  could generate a string that uses `\r\n` in its line breaks, thus any string comparison between the two would fail.

This PR will remove the carriage return to ensure that the line breaks are the same. 
