### PR TITLE
feat: add support for EXT-X-START tag w/ tests

### DIFF
--- a/m3u/AttributeList.js
+++ b/m3u/AttributeList.js
@@ -40,6 +40,8 @@ var dataTypes = AttributeList.dataTypes = {
   'key-keyformatversions': 'quoted-string',
   'map-uri'              : 'quoted-string',
   'map-byterange'        : 'quoted-string',
+  'start-timeoffset'     : 'decimal-floating-point',
+  'start-precise'        : 'boolean'
 };
 
 AttributeList.prototype.mergeAttributes = function mergeAttributes(attributes) {

--- a/m3u/PlaylistItem.js
+++ b/m3u/PlaylistItem.js
@@ -15,6 +15,13 @@ PlaylistItem.create = function createPlaylistItem(data) {
 
 PlaylistItem.prototype.toString = function toString() {
   var output = [];
+  if (this.get('start-timeoffset')) {
+    var line = `#EXT-X-START:TIME-OFFSET=${this.get('start-timeoffset')}`;
+    if (this.get('start-precise')) {
+      line += `,PRECISE=${this.get('start-precise')}`
+    }
+    output.push(line);
+  }
   if (this.get('map-uri')) {
     var line = `#EXT-X-MAP:URI="${this.get('map-uri')}"`;
     if (this.get('map-byterange')) {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     },
     "devDependencies": {
         "mocha": "~7.1.0",
-        "sinon": "~1.5.0",
-        "should": "7.1.1"
+        "should": "7.1.1",
+        "sinon": "~1.5.0"
     },
     "engine": {
         "node": ">=0.6.0"

--- a/parser.js
+++ b/parser.js
@@ -23,6 +23,7 @@ var m3uParser = module.exports = function m3uParser() {
   this.dateRangeData = null;
   this.key = null;
   this.map = null;
+  this.startOffset = null;
 
   this.on('data', this.parse.bind(this));
   var self = this;
@@ -158,6 +159,14 @@ m3uParser.prototype['EXTINF'] = function parseInf(data) {
     }
     this.map = null;
   }
+
+  if (this.startOffset !== null) {
+    this.currentItem.set('start-timeoffset', this.startOffset.timeOffset);
+    if (this.startOffset.precise) {
+      this.currentItem.set('start-precise', this.startOffset.precise);
+    }
+    this.startOffset = null;
+  }
 };
 
 m3uParser.prototype['EXT-X-DISCONTINUITY'] = function parseInf() {
@@ -289,6 +298,22 @@ m3uParser.prototype['EXT-X-MAP'] = function parseMap(data) {
   var byterange = attr.find(elem => elem.key.toLowerCase() === 'byterange');
   if (byterange) {
     this.map.byterange = byterange.value;
+  }
+};
+
+m3uParser.prototype['EXT-X-START'] = function parseInf(data) {
+  this.startOffset = {
+    timeOffset: null,
+    precise: null
+  }
+  var attr = this.parseAttributes(data);
+  var offset = attr.find(elem => elem.key.toLowerCase() === 'time-offset');
+  if (offset) {
+    this.startOffset.timeOffset = offset.value;
+  } 
+  var precise = attr.find(elem => elem.key.toLowerCase() === 'precise');
+  if (precise) {
+    this.startOffset.precise = precise.value;
   }
 };
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -208,6 +208,57 @@ describe('parser', function() {
     });
   });
 
+  describe('#EXT-X-START', function () {
+    it('should indicate start with attributes if present', function () {
+      var parser = getParser();
+      parser['EXT-X-START']('TIME-OFFSET=15,PRECISE=YES');
+      parser.EXTINF('10,some title');
+      parser.currentItem.constructor.name.should.eql('PlaylistItem');
+      parser.currentItem.get('start-timeoffset').should.eql(15);
+      parser.currentItem.get('start-precise').should.eql(true);
+    });
+    it('should indicate start with only timeoffset attribute if present', function () {
+      var parser = getParser();
+      parser['EXT-X-START']('TIME-OFFSET=15');
+      parser.EXTINF('10,some title');
+      parser.currentItem.constructor.name.should.eql('PlaylistItem');
+      parser.currentItem.get('start-timeoffset').should.eql(15);
+      (parser.currentItem.get('start-precise') === undefined).should.be.true();
+    });
+    it('should indicate start with only timeoffset attribute (decimal) if present', function () {
+      var parser = getParser();
+      parser['EXT-X-START']('TIME-OFFSET=15.625');
+      parser.EXTINF('10,some title');
+      parser.currentItem.constructor.name.should.eql('PlaylistItem');
+      parser.currentItem.get('start-timeoffset').should.eql(15.625);
+      (parser.currentItem.get('start-precise') === undefined).should.be.true();
+    });
+    it('should indicate start with only timeoffset attribute (negative decimal) if present', function () {
+      var parser = getParser();
+      parser['EXT-X-START']('TIME-OFFSET=-15.500');
+      parser.EXTINF('10,some title');
+      parser.currentItem.constructor.name.should.eql('PlaylistItem');
+      parser.currentItem.get('start-timeoffset').should.eql(-15.5);
+      (parser.currentItem.get('start-precise') === undefined).should.be.true();
+    });
+    it('should indicate start with only timeoffset attribute (negative integer) if present', function () {
+      var parser = getParser();
+      parser['EXT-X-START']('TIME-OFFSET=-15.500');
+      parser.EXTINF('10,some title');
+      parser.currentItem.constructor.name.should.eql('PlaylistItem');
+      parser.currentItem.get('start-timeoffset').should.eql(-15.5);
+      (parser.currentItem.get('start-precise') === undefined).should.be.true();
+    });
+    it('should indicate start with attributes (PRECISE=NO) if present', function () {
+      var parser = getParser();
+      parser['EXT-X-START']('TIME-OFFSET=15,PRECISE=NO');
+      parser.EXTINF('10,some title');
+      parser.currentItem.constructor.name.should.eql('PlaylistItem');
+      parser.currentItem.get('start-timeoffset').should.eql(15);
+      parser.currentItem.get('start-precise').should.eql(false);
+    });
+  });
+
   describe('#EXT-X-PROGRAM-DATE-TIME', function() {
     it('should indicate program-date-time with date if present', function() {
       var parser = getParser();

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -243,10 +243,10 @@ describe('parser', function() {
     });
     it('should indicate start with only timeoffset attribute (negative integer) if present', function () {
       var parser = getParser();
-      parser['EXT-X-START']('TIME-OFFSET=-15.500');
+      parser['EXT-X-START']('TIME-OFFSET=-15');
       parser.EXTINF('10,some title');
       parser.currentItem.constructor.name.should.eql('PlaylistItem');
-      parser.currentItem.get('start-timeoffset').should.eql(-15.5);
+      parser.currentItem.get('start-timeoffset').should.eql(-15);
       (parser.currentItem.get('start-precise') === undefined).should.be.true();
     });
     it('should indicate start with attributes (PRECISE=NO) if present', function () {


### PR DESCRIPTION
This PR will add support for the #EXT-X-START tag which was introduced to the HLS spec in version 6

with unit tests as well.