### PR TITLE
chore: when stringifying playlist item place cue in tag above cue out

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "semi": true,
+    "trailingComma": "all",
+    "tabWidth": 2,
+    "singleQuote": true,
+    "printWidth": 100
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
     "trailingComma": "all",
     "tabWidth": 2,
     "singleQuote": true,
-    "printWidth": 100
+    "printWidth": 140
 }

--- a/m3u/PlaylistItem.js
+++ b/m3u/PlaylistItem.js
@@ -75,10 +75,7 @@ PlaylistItem.prototype.toString = function toString() {
     var attr = this.get('daterange');
     var s = Object.keys(attr)
       .map(function (key) {
-        if (
-          attr['CLASS'] === 'com.apple.hls.interstitial' &&
-          (key === 'X-RESUME-OFFSET' || key === 'X-PLAYOUT-LIMIT')
-        ) {
+        if (attr['CLASS'] === 'com.apple.hls.interstitial' && (key === 'X-RESUME-OFFSET' || key === 'X-PLAYOUT-LIMIT')) {
           // The CLASS=com.apple.hls.interstitial has some daterange attributes
           // that are not quoted strings
           return key + '=' + `${attr[key]}`;

--- a/m3u/PlaylistItem.js
+++ b/m3u/PlaylistItem.js
@@ -1,5 +1,5 @@
-var util = require("util"),
-  Item = require("./Item");
+var util = require('util'),
+  Item = require('./Item');
 
 var PlaylistItem = (module.exports = function PlaylistItem() {
   Item.call(this);
@@ -15,91 +15,91 @@ PlaylistItem.create = function createPlaylistItem(data) {
 
 PlaylistItem.prototype.toString = function toString() {
   var output = [];
-  if (this.get("start-timeoffset")) {
-    var line = `#EXT-X-START:TIME-OFFSET=${this.get("start-timeoffset")}`;
-    if (this.get("start-precise")) {
-      line += `,PRECISE=${this.get("start-precise") ? "YES" : "NO"}`;
+  if (this.get('start-timeoffset')) {
+    var line = `#EXT-X-START:TIME-OFFSET=${this.get('start-timeoffset')}`;
+    if (this.get('start-precise')) {
+      line += `,PRECISE=${this.get('start-precise') ? 'YES' : 'NO'}`;
     }
     output.push(line);
   }
-  if (this.get("map-uri")) {
-    var line = `#EXT-X-MAP:URI="${this.get("map-uri")}"`;
-    if (this.get("map-byterange")) {
-      line += `,BYTERANGE=${this.get("map-byterange")}`;
+  if (this.get('map-uri')) {
+    var line = `#EXT-X-MAP:URI="${this.get('map-uri')}"`;
+    if (this.get('map-byterange')) {
+      line += `,BYTERANGE=${this.get('map-byterange')}`;
     }
     output.push(line);
   }
-  if (this.get("discontinuity")) {
-    output.push("#EXT-X-DISCONTINUITY");
+  if (this.get('discontinuity')) {
+    output.push('#EXT-X-DISCONTINUITY');
   }
-  if (this.get("cuein")) {
-    output.push("#EXT-X-CUE-IN");
+  if (this.get('cuein')) {
+    output.push('#EXT-X-CUE-IN');
   }
-  if (this.get("cueout")) {
-    var duration = this.get("cueout");
-    output.push("#EXT-X-CUE-OUT:DURATION=" + duration);
+  if (this.get('cueout')) {
+    var duration = this.get('cueout');
+    output.push('#EXT-X-CUE-OUT:DURATION=' + duration);
   }
-  if (this.get("cont-offset") && this.get("cont-dur")) {
-    var cueOutContOffset = this.get("cont-offset");
-    var cueOutContDuration = this.get("cont-dur");
-    output.push("#EXT-X-CUE-OUT-CONT:" + cueOutContOffset + "/" + cueOutContDuration);
+  if (this.get('cont-offset') && this.get('cont-dur')) {
+    var cueOutContOffset = this.get('cont-offset');
+    var cueOutContDuration = this.get('cont-dur');
+    output.push('#EXT-X-CUE-OUT-CONT:' + cueOutContOffset + '/' + cueOutContDuration);
   }
-  if (this.get("date")) {
-    var date = this.get("date");
+  if (this.get('date')) {
+    var date = this.get('date');
     if (date.getMonth) {
       date = date.toISOString();
     }
-    output.push("#EXT-X-PROGRAM-DATE-TIME:" + date);
+    output.push('#EXT-X-PROGRAM-DATE-TIME:' + date);
   }
-  if (this.get("key-method")) {
-    var line = `#EXT-X-KEY:METHOD=${this.get("key-method")}`;
-    if (this.get("key-uri")) {
-      line += `,URI="${this.get("key-uri")}"`;
+  if (this.get('key-method')) {
+    var line = `#EXT-X-KEY:METHOD=${this.get('key-method')}`;
+    if (this.get('key-uri')) {
+      line += `,URI="${this.get('key-uri')}"`;
     }
-    if (this.get("key-iv")) {
-      line += `,IV=${this.get("key-iv")}`;
+    if (this.get('key-iv')) {
+      line += `,IV=${this.get('key-iv')}`;
     }
-    if (this.get("key-keyformat")) {
-      line += `,KEYFORMAT="${this.get("key-keyformat")}"`;
+    if (this.get('key-keyformat')) {
+      line += `,KEYFORMAT="${this.get('key-keyformat')}"`;
     }
-    if (this.get("key-keyformatversions")) {
-      line += `,KEYFORMATVERSIONS="${this.get("key-keyformatversions")}"`;
+    if (this.get('key-keyformatversions')) {
+      line += `,KEYFORMATVERSIONS="${this.get('key-keyformatversions')}"`;
     }
     output.push(line);
   }
 
-  if (this.get("daiPlacementOpportunity")) {
-    output.push("#EXT-X-PLACEMENT-OPPORTUNITY");
+  if (this.get('daiPlacementOpportunity')) {
+    output.push('#EXT-X-PLACEMENT-OPPORTUNITY');
   }
-  if (this.get("daterange") != null) {
-    var attr = this.get("daterange");
+  if (this.get('daterange') != null) {
+    var attr = this.get('daterange');
     var s = Object.keys(attr)
       .map(function (key) {
         if (
-          attr["CLASS"] === "com.apple.hls.interstitial" &&
-          (key === "X-RESUME-OFFSET" || key === "X-PLAYOUT-LIMIT")
+          attr['CLASS'] === 'com.apple.hls.interstitial' &&
+          (key === 'X-RESUME-OFFSET' || key === 'X-PLAYOUT-LIMIT')
         ) {
           // The CLASS=com.apple.hls.interstitial has some daterange attributes
           // that are not quoted strings
-          return key + "=" + `${attr[key]}`;
-        } else if (key === "DURATION") {
-          return key + "=" + `${attr[key]}`;
+          return key + '=' + `${attr[key]}`;
+        } else if (key === 'DURATION') {
+          return key + '=' + `${attr[key]}`;
         } else {
-          return key + "=" + `"${attr[key]}"`;
+          return key + '=' + `"${attr[key]}"`;
         }
       })
-      .join(",");
-    output.push("#EXT-X-DATERANGE:" + s);
+      .join(',');
+    output.push('#EXT-X-DATERANGE:' + s);
   }
-  if (this.get("duration") != null || this.get("title") != null) {
-    output.push("#EXTINF:" + [this.get("duration").toFixed(4), this.get("title")].join(","));
+  if (this.get('duration') != null || this.get('title') != null) {
+    output.push('#EXTINF:' + [this.get('duration').toFixed(4), this.get('title')].join(','));
   }
-  if (this.get("byteRange") != null) {
-    output.push("#EXT-X-BYTERANGE:" + this.get("byteRange"));
+  if (this.get('byteRange') != null) {
+    output.push('#EXT-X-BYTERANGE:' + this.get('byteRange'));
   }
-  if (this.get("uri")) {
-    output.push(this.get("uri"));
+  if (this.get('uri')) {
+    output.push(this.get('uri'));
   }
 
-  return output.join("\n");
+  return output.join('\n');
 };

--- a/m3u/PlaylistItem.js
+++ b/m3u/PlaylistItem.js
@@ -1,9 +1,9 @@
-var util = require('util'),
-    Item = require('./Item');
+var util = require("util"),
+  Item = require("./Item");
 
-var PlaylistItem = module.exports = function PlaylistItem() {
+var PlaylistItem = (module.exports = function PlaylistItem() {
   Item.call(this);
-};
+});
 
 util.inherits(PlaylistItem, Item);
 
@@ -15,88 +15,91 @@ PlaylistItem.create = function createPlaylistItem(data) {
 
 PlaylistItem.prototype.toString = function toString() {
   var output = [];
-  if (this.get('start-timeoffset')) {
-    var line = `#EXT-X-START:TIME-OFFSET=${this.get('start-timeoffset')}`;
-    if (this.get('start-precise')) {
-      line += `,PRECISE=${this.get('start-precise') ? 'YES' : 'NO'}`
+  if (this.get("start-timeoffset")) {
+    var line = `#EXT-X-START:TIME-OFFSET=${this.get("start-timeoffset")}`;
+    if (this.get("start-precise")) {
+      line += `,PRECISE=${this.get("start-precise") ? "YES" : "NO"}`;
     }
     output.push(line);
   }
-  if (this.get('map-uri')) {
-    var line = `#EXT-X-MAP:URI="${this.get('map-uri')}"`;
-    if (this.get('map-byterange')) {
-      line += `,BYTERANGE=${this.get('map-byterange')}`
+  if (this.get("map-uri")) {
+    var line = `#EXT-X-MAP:URI="${this.get("map-uri")}"`;
+    if (this.get("map-byterange")) {
+      line += `,BYTERANGE=${this.get("map-byterange")}`;
     }
     output.push(line);
   }
-  if (this.get('discontinuity')) {
-    output.push('#EXT-X-DISCONTINUITY');
+  if (this.get("discontinuity")) {
+    output.push("#EXT-X-DISCONTINUITY");
   }
-  if (this.get('cueout')) {
-    var duration = this.get('cueout');
-    output.push('#EXT-X-CUE-OUT:DURATION=' + duration);
+  if (this.get("cuein")) {
+    output.push("#EXT-X-CUE-IN");
   }
-  if (this.get('cont-offset') && this.get('cont-dur')) {
-    var cueOutContOffset = this.get('cont-offset');
-    var cueOutContDuration = this.get('cont-dur');
-    output.push('#EXT-X-CUE-OUT-CONT:' + cueOutContOffset + "/" + cueOutContDuration);
+  if (this.get("cueout")) {
+    var duration = this.get("cueout");
+    output.push("#EXT-X-CUE-OUT:DURATION=" + duration);
   }
-  if (this.get('cuein')) {
-    output.push('#EXT-X-CUE-IN');
+  if (this.get("cont-offset") && this.get("cont-dur")) {
+    var cueOutContOffset = this.get("cont-offset");
+    var cueOutContDuration = this.get("cont-dur");
+    output.push("#EXT-X-CUE-OUT-CONT:" + cueOutContOffset + "/" + cueOutContDuration);
   }
-  if (this.get('date')) {
-    var date = this.get('date');
+  if (this.get("date")) {
+    var date = this.get("date");
     if (date.getMonth) {
       date = date.toISOString();
     }
-    output.push('#EXT-X-PROGRAM-DATE-TIME:' + date);
+    output.push("#EXT-X-PROGRAM-DATE-TIME:" + date);
   }
-  if (this.get('key-method')) {
-    var line = `#EXT-X-KEY:METHOD=${this.get('key-method')}`;
-    if (this.get('key-uri')) {
-      line += `,URI="${this.get('key-uri')}"`;
+  if (this.get("key-method")) {
+    var line = `#EXT-X-KEY:METHOD=${this.get("key-method")}`;
+    if (this.get("key-uri")) {
+      line += `,URI="${this.get("key-uri")}"`;
     }
-    if (this.get('key-iv')) {
-      line += `,IV=${this.get('key-iv')}`;
+    if (this.get("key-iv")) {
+      line += `,IV=${this.get("key-iv")}`;
     }
-    if (this.get('key-keyformat')) {
-      line += `,KEYFORMAT="${this.get('key-keyformat')}"`;
+    if (this.get("key-keyformat")) {
+      line += `,KEYFORMAT="${this.get("key-keyformat")}"`;
     }
-    if (this.get('key-keyformatversions')) {
-      line += `,KEYFORMATVERSIONS="${this.get('key-keyformatversions')}"`;
+    if (this.get("key-keyformatversions")) {
+      line += `,KEYFORMATVERSIONS="${this.get("key-keyformatversions")}"`;
     }
-    output.push(line)
+    output.push(line);
   }
 
-  if (this.get('daiPlacementOpportunity')) {
-    output.push('#EXT-X-PLACEMENT-OPPORTUNITY');
+  if (this.get("daiPlacementOpportunity")) {
+    output.push("#EXT-X-PLACEMENT-OPPORTUNITY");
   }
-  if (this.get('daterange') != null) {
-    var attr = this.get('daterange');
-    var s = Object.keys(attr).map(function(key) {
-      if (attr['CLASS'] === "com.apple.hls.interstitial" && (key === 'X-RESUME-OFFSET' || key === 'X-PLAYOUT-LIMIT')) {
-        // The CLASS=com.apple.hls.interstitial has some daterange attributes
-        // that are not quoted strings
-        return key + "=" + `${attr[key]}`;
-      } else if (key === 'DURATION') {
-        return key + "=" + `${attr[key]}`;
-      } else {
-        return key + "=" + `"${attr[key]}"`;
-      }
-    }).join(',');
-    output.push('#EXT-X-DATERANGE:' + s);
+  if (this.get("daterange") != null) {
+    var attr = this.get("daterange");
+    var s = Object.keys(attr)
+      .map(function (key) {
+        if (
+          attr["CLASS"] === "com.apple.hls.interstitial" &&
+          (key === "X-RESUME-OFFSET" || key === "X-PLAYOUT-LIMIT")
+        ) {
+          // The CLASS=com.apple.hls.interstitial has some daterange attributes
+          // that are not quoted strings
+          return key + "=" + `${attr[key]}`;
+        } else if (key === "DURATION") {
+          return key + "=" + `${attr[key]}`;
+        } else {
+          return key + "=" + `"${attr[key]}"`;
+        }
+      })
+      .join(",");
+    output.push("#EXT-X-DATERANGE:" + s);
   }
-  if (this.get('duration') != null || this.get('title') != null) {
-    output.push(
-      '#EXTINF:' + [this.get('duration').toFixed(4), this.get('title')].join(',')
-    );
+  if (this.get("duration") != null || this.get("title") != null) {
+    output.push("#EXTINF:" + [this.get("duration").toFixed(4), this.get("title")].join(","));
   }
-  if (this.get('byteRange') != null) {
-    output.push('#EXT-X-BYTERANGE:' + this.get('byteRange'));
+  if (this.get("byteRange") != null) {
+    output.push("#EXT-X-BYTERANGE:" + this.get("byteRange"));
   }
-  if(this.get('uri')) {
-    output.push(this.get('uri'));
+  if (this.get("uri")) {
+    output.push(this.get("uri"));
   }
 
-  return output.join('\n');
+  return output.join("\n");
 };


### PR DESCRIPTION
This PR resolves a case where a playlist manifest has back-to-back ad breaks, and the cue-out tag has an earlier printout priority over the cue-in tag. In a case when a playlistItem has both, will result in a manifest that might cause some confusion to the player in regards to when a certain adbreak has truly ended.

ei 
```
#EXTM3U
#EXT-X-VERSION:6
## Created with Unified Streaming Platform (version=1.11.20-26889)
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MEDIA-SEQUENCE:1
#EXT-X-INDEPENDENT-SEGMENTS
#EXT-X-TARGETDURATION:3
#USP-X-TIMESTAMP-MAP:MPEGTS=900000,LOCAL=1970-01-01T00:00:00Z     
#EXT-X-MAP:URI="http://mock.com/ad/mock-ad3-video=2525000.m4s"    
#EXT-X-DISCONTINUITY
#EXT-X-CUE-OUT:DURATION=3
#EXTINF:3.0000, no desc
http://mock.com/ad/mock-ad3-video=2525000-1.m4s
#EXT-X-MAP:URI="http://mock.com/ad/mock-ad-video=2525000.m4s"     
#EXT-X-DISCONTINUITY
#EXT-X-CUE-OUT:DURATION=14.16
#EXT-X-CUE-IN        <------------(Potentially looks like the 14s break cued in immediatly)
#EXTINF:3.0000, no desc
http://mock.com/ad/mock-ad-video=2525000-1.m4s
```
This would be clearer
```
#EXTM3U
#EXT-X-VERSION:6
## Created with Unified Streaming Platform (version=1.11.20-26889)
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MEDIA-SEQUENCE:1
#EXT-X-INDEPENDENT-SEGMENTS
#EXT-X-TARGETDURATION:3
#USP-X-TIMESTAMP-MAP:MPEGTS=900000,LOCAL=1970-01-01T00:00:00Z     
#EXT-X-MAP:URI="http://mock.com/ad/mock-ad3-video=2525000.m4s"
#EXT-X-DISCONTINUITY
#EXT-X-CUE-OUT:DURATION=3
#EXTINF:3.0000, no desc
http://mock.com/ad/mock-ad3-video=2525000-1.m4s
#EXT-X-MAP:URI="http://mock.com/ad/mock-ad-video=2525000.m4s"
#EXT-X-DISCONTINUITY
#EXT-X-CUE-IN
#EXT-X-CUE-OUT:DURATION=14.16
#EXTINF:3.0000, no desc
http://mock.com/ad/mock-ad-video=2525000-1.m4s
```