### PR TITLE
Fix: add better attribute parsing helper function

### DIFF
--- a/m3u.js
+++ b/m3u.js
@@ -104,10 +104,23 @@ M3U.prototype.toString = function toString() {
   });
 
   if (this.items.PlaylistItem.length) {
+    let cuedInterstitial = false;
+    let final_interstitial_item = null;
+    if (this.items.PlaylistItem[this.items.PlaylistItem.length - 1].get("daterange") &&
+    this.items.PlaylistItem[this.items.PlaylistItem.length - 1].get("daterange")["CLASS"] == "com.apple.hls.interstitial" &&
+    this.items.PlaylistItem[this.items.PlaylistItem.length - 1].get("daterange")["CUE"]
+  ) {
+      cuedInterstitial = true;
+    }
+    if (cuedInterstitial) {
+      final_interstitial_item = this.items.PlaylistItem.pop()
+    }
     output.push(this.items.PlaylistItem.map(itemToString).join('\n'));
-
     if (this.get('playlistType') === 'VOD') {
       output.push('#EXT-X-ENDLIST');
+      if (final_interstitial_item) {
+        output.push(final_interstitial_item.toString());
+      }
     }
   } else {
     if (this.items.StreamItem.length) {

--- a/m3u/AttributeList.js
+++ b/m3u/AttributeList.js
@@ -142,6 +142,18 @@ function parseQuotedString(value) {
   }
 }
 
+function parseAttributeStringToDict(inputString) {
+  const data = {};
+  const regex = /([\w-]+)=(".*?"|[^,]+)/g;
+  let match;
+  while ((match = regex.exec(inputString)) !== null) {
+      const key = match[1]; 
+      const value = match[2].replace(/^"|"$/g, ''); 
+      data[key] = value; 
+  }
+  return data; 
+}
+
 var parse = {
   'boolean': function parseBoolean(value) {
     return typeof value == 'boolean'
@@ -161,20 +173,7 @@ var parse = {
   'quoted-string': parseQuotedString,
   'closed-captions': parseQuotedString,
   'quoted-string-array': function parseQuotedStringArray(value) {
-    var data = {};
-    value.split(',').map(function(kv) {
-      var s = kv.split('=');
-      var unquoted = "";
-      if (s[1]) {
-        if (s[1].indexOf('"') === 0 && s[1].lastIndexOf('"') == s[1].length - 1) {
-          unquoted = s[1].slice(1, -1);
-        } else {
-          unquoted = s[1];
-        }
-        data[s[0]] = unquoted;
-      }
-    });
-    return data;
+   return parseAttributeStringToDict(value);
   },
   'hexadecimal-sequence': function parseHexadecimalSequence(value) {
     return value;


### PR DESCRIPTION
Issue: When parsing an attribute which may have a value that is comma-separated string, the current version cuts of parts of that value. eg. a line like `#EXT-X-DATERANGE:ID="2",CLASS="com.apple.hls.interstitial",CUE="PRE,POST"` would be parsed as
```
{
ID: "2",
CLASS: "com.apple.hls.interstitial",
CUE: "PRE" // expecting "PRE,POST"
}
```
This is due to the original parsing logic splits in "," first. 

This PR fixes this by adding a better and more accurate parser function.