### PR TITLE
Fix: revert the special case for handling daterange cue attribute 

### DIFF
--- a/m3u.js
+++ b/m3u.js
@@ -104,23 +104,9 @@ M3U.prototype.toString = function toString() {
   });
 
   if (this.items.PlaylistItem.length) {
-    let cuedInterstitial = false;
-    let final_interstitial_item = null;
-    if (this.items.PlaylistItem[this.items.PlaylistItem.length - 1].get("daterange") &&
-    this.items.PlaylistItem[this.items.PlaylistItem.length - 1].get("daterange")["CLASS"] == "com.apple.hls.interstitial" &&
-    this.items.PlaylistItem[this.items.PlaylistItem.length - 1].get("daterange")["CUE"]
-  ) {
-      cuedInterstitial = true;
-    }
-    if (cuedInterstitial) {
-      final_interstitial_item = this.items.PlaylistItem.pop()
-    }
     output.push(this.items.PlaylistItem.map(itemToString).join('\n'));
     if (this.get('playlistType') === 'VOD') {
       output.push('#EXT-X-ENDLIST');
-      if (final_interstitial_item) {
-        output.push(final_interstitial_item.toString());
-      }
     }
   } else {
     if (this.items.StreamItem.length) {


### PR DESCRIPTION
A mistake on my part. This step turned out to be unnecessary. This PR reverts that specific part of the previous change.